### PR TITLE
Link DOIs to preferred resolver

### DIFF
--- a/QFT/biblatex.tex
+++ b/QFT/biblatex.tex
@@ -49,7 +49,7 @@
 %\AtEveryBibitem{\clearfield{issn}} \AtEveryCitekey{\clearfield{issn}}
 %\ExecuteBibliographyOptions{doi=false}
 %\newbibmacro{string+doi}[1]{%
-%  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+%  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 
     % http://tex.stackexchange.com/questions/133373/biblatex-adding-url-to-techreport-title-doesnt-work/133374#133374
 \DeclareFieldFormat
@@ -81,7 +81,7 @@
       \href{\thefield{url}}{#1}%
     }%
   }{%
-    \href{http://dx.doi.org/\thefield{doi}}{#1}%
+    \href{https://doi.org/\thefield{doi}}{#1}%
   }%
 }
 

--- a/bibtex/ChaosBook.bib
+++ b/bibtex/ChaosBook.bib
@@ -22492,7 +22492,7 @@ http://research.microsoft.com/en-US/people/kannan/book-no-solutions-aug-21-2014.
   year    = {2007},
   volume  = {114},
   pages   = {1278 - 1292},
-  doi     = {http://dx.doi.org/10.1016/j.jcta.2007.01.008},
+  doi     = {https://doi.org/10.1016/j.jcta.2007.01.008},
 }
 
 @Book{Kadanoff00,

--- a/bibtex/DasGroup.bib
+++ b/bibtex/DasGroup.bib
@@ -2455,7 +2455,7 @@
   year    = {2007},
   volume  = {114},
   pages   = {1278 - 1292},
-  doi     = {http://dx.doi.org/10.1016/j.jcta.2007.01.008},
+  doi     = {https://doi.org/10.1016/j.jcta.2007.01.008},
 }
 
 @Article{MoMoPo17,

--- a/bibtex/QFT.bib
+++ b/bibtex/QFT.bib
@@ -1095,7 +1095,7 @@ behaviour is estimated. },
   year =    {2016},
   volume =  {57},
   pages =   {092301},
-  doi =     {http://dx.doi.org/10.1063/1.4962800}
+  doi =     {https://doi.org/10.1063/1.4962800}
 }
 
 @Article{NPB81,
@@ -2984,7 +2984,7 @@ subject. },
   volume  = {63},
   pages   = {462--469},
   doi     = {10.1007/BF01017902},
-  url     = {http://dx.doi.org/10.1007/BF01017902},
+  url     = {https://doi.org/10.1007/BF01017902},
 }
 
 @Article{JohZum59,

--- a/bibtex/siminos.bib
+++ b/bibtex/siminos.bib
@@ -16527,7 +16527,7 @@ in comparison to a scheme without freezing. },
   Pages                    = {137--146},
   Volume                   = {7},
   DOI                      = {10.1007/bf01078886},
-  URL                      = {http://dx.doi.org/10.1007/bf01078886}
+  URL                      = {https://doi.org/10.1007/bf01078886}
 }
 
 @Article{romero-bastida2012,
@@ -17287,7 +17287,7 @@ two-dimensional maps.},
   Pages                    = {329--341},
   Volume                   = {19},
   DOI                      = {10.1175/1520-0469(1962)019<0329:fafcaa>2.0.co;2},
-  URL                      = {http://dx.doi.org/10.1175/1520-0469(1962)019<0329:fafcaa>2.0.co;2}
+  URL                      = {https://doi.org/10.1175/1520-0469(1962)019<0329:fafcaa>2.0.co;2}
 }
 
 @Article{samelson01,
@@ -18147,7 +18147,7 @@ two-dimensional maps.},
   Pages                    = {211--214},
   Volume                   = {120},
   DOI                      = {10.1016/0375-9601(87)90209-x},
-  URL                      = {http://dx.doi.org/10.1016/0375-9601(87)90209-x}
+  URL                      = {https://doi.org/10.1016/0375-9601(87)90209-x}
 }
 
 @Article{Sirovich94,

--- a/cgang/arXiv-v1/2modes.bbl
+++ b/cgang/arXiv-v1/2modes.bbl
@@ -38,7 +38,7 @@
 \providecommand \@url [1]{\endgroup\@href {#1}{\urlprefix }}%
 \providecommand \urlprefix  [0]{URL }%
 \providecommand \Eprint [0]{\href }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo  [0]{\@secondoftwo}%
 \providecommand \bibfield  [0]{\@secondoftwo}%

--- a/cgang/arXiv-v2/2modes.bbl
+++ b/cgang/arXiv-v2/2modes.bbl
@@ -44,7 +44,7 @@
   \providecommand \doi [0]{doi:\discretionary{}{}{}\begingroup
   \urlstyle{rm}\Url }%
 }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \Doi[1]{\href{\doibase#1}}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo [0]{\@secondoftwo}%

--- a/cgang/arXiv-v3/2modes.bbl
+++ b/cgang/arXiv-v3/2modes.bbl
@@ -38,7 +38,7 @@
 \providecommand \@url [1]{\endgroup\@href {#1}{\urlprefix }}%
 \providecommand \urlprefix  [0]{URL }%
 \providecommand \Eprint [0]{\href }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo  [0]{\@secondoftwo}%
 \providecommand \bibfield  [0]{\@secondoftwo}%

--- a/cgang/arXiv-v4/2modes.bbl
+++ b/cgang/arXiv-v4/2modes.bbl
@@ -38,7 +38,7 @@
 \providecommand \@url [1]{\endgroup\@href {#1}{\urlprefix }}%
 \providecommand \urlprefix  [0]{URL }%
 \providecommand \Eprint [0]{\href }%
-\providecommand \doibase [0]{http://dx.doi.org/}%
+\providecommand \doibase [0]{https://doi.org/}%
 \providecommand \selectlanguage [0]{\@gobble}%
 \providecommand \bibinfo  [0]{\@secondoftwo}%
 \providecommand \bibfield  [0]{\@secondoftwo}%

--- a/dasgroup/biblatex.tex
+++ b/dasgroup/biblatex.tex
@@ -49,7 +49,7 @@
 %\AtEveryBibitem{\clearfield{issn}} \AtEveryCitekey{\clearfield{issn}}
 %\ExecuteBibliographyOptions{doi=false}
 %\newbibmacro{string+doi}[1]{%
-%  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+%  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 
     % http://tex.stackexchange.com/questions/133373/biblatex-adding-url-to-techreport-title-doesnt-work/133374#133374
 \DeclareFieldFormat
@@ -81,7 +81,7 @@
       \href{\thefield{url}}{#1}%
     }%
   }{%
-    \href{http://dx.doi.org/\thefield{doi}}{#1}%
+    \href{https://doi.org/\thefield{doi}}{#1}%
   }%
 }
 

--- a/inputs/biblatex.tex
+++ b/inputs/biblatex.tex
@@ -42,7 +42,7 @@
 %\AtEveryBibitem{\clearfield{issn}} \AtEveryCitekey{\clearfield{issn}}
 %\ExecuteBibliographyOptions{doi=false}
 %\newbibmacro{string+doi}[1]{%
-%  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+%  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 %\DeclareFieldFormat{title}{\usebibmacro{string+doi}{\mkbibemph{#1}}}
 %\DeclareFieldFormat[article]{title}{\usebibmacro{string+doi}{\mkbibquote{#1}}}
 
@@ -75,7 +75,7 @@
       \href{\thefield{url}}{#1}%
     }%
   }{%
-    \href{http://dx.doi.org/\thefield{doi}}{#1}%
+    \href{https://doi.org/\thefield{doi}}{#1}%
   }%
 }
 

--- a/linresp/setupLinresp.tex
+++ b/linresp/setupLinresp.tex
@@ -40,7 +40,7 @@
 \AtEveryBibitem{\clearfield{issn}} \AtEveryCitekey{\clearfield{issn}}
 \ExecuteBibliographyOptions{doi=false}
 \newbibmacro{string+doi}[1]{%
-  \iffieldundef{doi}{#1}{\href{http://dx.doi.org/\thefield{doi}}{#1}}}
+  \iffieldundef{doi}{#1}{\href{https://doi.org/\thefield{doi}}{#1}}}
 \DeclareFieldFormat{title}{\usebibmacro{string+doi}{\mkbibemph{#1}}}
 \DeclareFieldFormat[article]{title}{\usebibmacro{string+doi}{\mkbibquote{#1}}}
 \fi % end \ifblog  %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Hello :-)

The DOI foundation recommends [this new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8). Accordingly, this PR updates static DOI links and the code that generates new ones.

Cheers!